### PR TITLE
feat: add constellation tools — QSFE forecast, knowledge query, constellation status

### DIFF
--- a/.aurora/constellation.json
+++ b/.aurora/constellation.json
@@ -1,0 +1,33 @@
+{
+  "constellation_version": "1.0.0-alpha",
+  "node": {
+    "designation": "AURORA-RUNTIME",
+    "symbolic_tag": "s.tag::aurora.runtime",
+    "repo": "AuroraOS",
+    "role": "spoke",
+    "stack": ["typescript", "mastra"],
+    "description": "Agent runtime — MCP server, Slack integration, Inngest workflows, constellation tool gateway"
+  },
+  "upstream": [
+    "s.tag::constellation.prime"
+  ],
+  "downstream": [],
+  "governance": {
+    "charter": "Picard_Delta_3",
+    "l3_modules": ["Axiomera", "Velatrix", "Glyphon", "Caelion", "Harmion"],
+    "ethics_protocol": true
+  },
+  "contracts": {
+    "published": [],
+    "consumed": ["forecast-request", "forecast-result", "knowledge-index", "constellation-health"]
+  },
+  "health": {
+    "last_sync": null,
+    "status": "active"
+  },
+  "meta": {
+    "created": "2026-03-13T11:00:00-04:00",
+    "created_by": "Perplexity Computer",
+    "proposal_ref": "Aurora Constellation Architecture Proposal v1.0.0"
+  }
+}

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -29,6 +29,9 @@ import { continuityManagementTool } from "./tools/continuityManagementTool";
 import { perplexityResearchTool } from "./tools/perplexityResearchTool";
 import { triluxOperationsTool } from "./tools/triluxOperationsTool";
 import { ethicsProtocolTool } from "./tools/ethicsProtocolTool";
+import { qgiaForecastTool } from "./tools/qgiaForecastTool";
+import { knowledgeQueryTool } from "./tools/knowledgeQueryTool";
+import { constellationStatusTool } from "./tools/constellationStatusTool";
 
 class ProductionPinoLogger extends MastraLogger {
   protected logger: pino.Logger;
@@ -91,6 +94,9 @@ export const mastra = new Mastra({
         perplexityResearchTool,
         triluxOperationsTool,
         ethicsProtocolTool,
+        qgiaForecastTool,
+        knowledgeQueryTool,
+        constellationStatusTool,
       },
     }),
   },

--- a/src/mastra/tools/constellationStatusTool.ts
+++ b/src/mastra/tools/constellationStatusTool.ts
@@ -1,0 +1,118 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+interface ConstellationManifest {
+  constellation_version: string;
+  node: {
+    designation: string;
+    symbolic_tag: string;
+    repo: string;
+    role: string;
+    stack: string[];
+    description: string;
+  };
+  health: {
+    last_sync: string | null;
+    status: string;
+  };
+}
+
+const CONSTELLATION_NODES = [
+  { repo: "aurora-cloudbank-symbolic", designation: "CONSTELLATION-PRIME", role: "hub" },
+  { repo: "AuroraOS", designation: "AURORA-RUNTIME", role: "spoke" },
+  { repo: "cloudbank-quantum-en", designation: "QUANTUM-VAULT", role: "spoke" },
+  { repo: "qgia-knowledge-library", designation: "QGIA-CORPUS", role: "spoke" },
+  { repo: "qgia-knowledge-spine", designation: "QGIA-SPINE", role: "spoke" },
+  { repo: "zip_wizard", designation: "ZIPWIZ-ENGINE", role: "spoke" },
+];
+
+export const constellationStatusTool = createTool({
+  id: "constellation-status",
+  description:
+    "Check the health and status of all Aurora Constellation nodes. Reports which nodes have registered their manifests, their current health status, and connectivity to the hub.",
+  inputSchema: z.object({
+    node_filter: z
+      .string()
+      .optional()
+      .describe(
+        "Filter by node designation (e.g., 'QGIA-CORPUS') or 'all' for all nodes",
+      ),
+  }),
+  outputSchema: z.object({
+    constellation_version: z.string(),
+    checked_at: z.string(),
+    nodes: z.array(
+      z.object({
+        designation: z.string(),
+        repo: z.string(),
+        role: z.string(),
+        status: z.string(),
+        manifest_present: z.boolean(),
+        description: z.string(),
+        stack: z.array(z.string()),
+        last_sync: z.string().nullable(),
+      }),
+    ),
+    summary: z.object({
+      total_nodes: z.number(),
+      active_nodes: z.number(),
+      initializing_nodes: z.number(),
+      unreachable_nodes: z.number(),
+    }),
+  }),
+  execute: async ({ context }) => {
+    const filter = context.node_filter;
+    const nodesToCheck =
+      filter && filter !== "all"
+        ? CONSTELLATION_NODES.filter((n) => n.designation === filter || n.repo === filter)
+        : CONSTELLATION_NODES;
+
+    const results = await Promise.all(
+      nodesToCheck.map(async (node) => {
+        try {
+          const url = `https://raw.githubusercontent.com/AUo959/${node.repo}/main/.aurora/constellation.json`;
+          const response = await fetch(url);
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          const manifest: ConstellationManifest = await response.json();
+          return {
+            designation: manifest.node.designation,
+            repo: node.repo,
+            role: manifest.node.role,
+            status: manifest.health.status,
+            manifest_present: true,
+            description: manifest.node.description,
+            stack: manifest.node.stack,
+            last_sync: manifest.health.last_sync,
+          };
+        } catch {
+          return {
+            designation: node.designation,
+            repo: node.repo,
+            role: node.role,
+            status: "unreachable",
+            manifest_present: false,
+            description: "Manifest not found or unreachable",
+            stack: [] as string[],
+            last_sync: null,
+          };
+        }
+      }),
+    );
+
+    const active = results.filter((r) => r.status === "active").length;
+    const initializing = results.filter((r) => r.status === "initializing").length;
+    const unreachable = results.filter((r) => r.status === "unreachable").length;
+
+    return {
+      constellation_version: "1.0.0-alpha",
+      checked_at: new Date().toISOString(),
+      nodes: results,
+      summary: {
+        total_nodes: results.length,
+        active_nodes: active,
+        initializing_nodes: initializing,
+        unreachable_nodes: unreachable,
+      },
+    };
+  },
+});

--- a/src/mastra/tools/knowledgeQueryTool.ts
+++ b/src/mastra/tools/knowledgeQueryTool.ts
@@ -1,0 +1,147 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+interface KnowledgeDocument {
+  id: string;
+  title: string;
+  domain: string;
+  path: string;
+  checksum: string;
+  word_count: number;
+  last_modified: string;
+  tags: string[];
+  summary: string;
+}
+
+interface KnowledgeIndex {
+  version: string;
+  source_repo: string;
+  generated_at: string;
+  documents: KnowledgeDocument[];
+}
+
+const KNOWLEDGE_INDEX_URLS = [
+  "https://raw.githubusercontent.com/AUo959/aurora-cloudbank-symbolic/main/knowledge-indexes/aggregated-knowledge-index.json",
+  "https://raw.githubusercontent.com/AUo959/qgia-knowledge-library/main/.aurora/knowledge-index.json",
+  "https://raw.githubusercontent.com/AUo959/qgia-knowledge-spine/main/.aurora/knowledge-index.json",
+];
+
+async function fetchKnowledgeIndex(): Promise<KnowledgeDocument[]> {
+  const allDocs: KnowledgeDocument[] = [];
+  const seen = new Set<string>();
+
+  for (const url of KNOWLEDGE_INDEX_URLS) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) continue;
+      const index: KnowledgeIndex = await response.json();
+      for (const doc of index.documents) {
+        if (!seen.has(doc.id)) {
+          seen.add(doc.id);
+          allDocs.push(doc);
+        }
+      }
+      // If we got the aggregated index, that's sufficient
+      if (url.includes("aggregated")) break;
+    } catch {
+      continue;
+    }
+  }
+
+  return allDocs;
+}
+
+function scoreDocument(
+  doc: KnowledgeDocument,
+  query: string,
+  domainFilter?: string,
+  tagFilter?: string[],
+): number {
+  if (domainFilter && doc.domain !== domainFilter) return -1;
+  if (tagFilter?.length && !tagFilter.some((t) => doc.tags.includes(t))) return -1;
+
+  const queryTerms = query.toLowerCase().split(/\s+/);
+  let score = 0;
+
+  for (const term of queryTerms) {
+    if (doc.title.toLowerCase().includes(term)) score += 3;
+    if (doc.summary.toLowerCase().includes(term)) score += 2;
+    if (doc.domain.toLowerCase().includes(term)) score += 1;
+    if (doc.tags.some((t) => t.includes(term))) score += 1;
+  }
+
+  return score;
+}
+
+export const knowledgeQueryTool = createTool({
+  id: "knowledge-query",
+  description:
+    "Search the QGIA knowledge base across the constellation. Queries the aggregated knowledge index from QGIA-CORPUS (domain knowledge) and QGIA-SPINE (methodologies) to find relevant intelligence documents, analytical frameworks, and methodological references.",
+  inputSchema: z.object({
+    query: z
+      .string()
+      .describe("Search query — natural language description of what you're looking for"),
+    domain: z
+      .string()
+      .optional()
+      .describe(
+        "Filter by domain (e.g., 'theoretical-foundations', 'analytical-frameworks', 'regional-expertise', 'tier1-methodological-foundations')",
+      ),
+    tags: z.array(z.string()).optional().describe("Filter by tags"),
+    max_results: z
+      .number()
+      .min(1)
+      .max(20)
+      .default(5)
+      .describe("Maximum number of results to return"),
+  }),
+  outputSchema: z.object({
+    query: z.string(),
+    total_indexed: z.number(),
+    results: z.array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        domain: z.string(),
+        path: z.string(),
+        word_count: z.number(),
+        summary: z.string(),
+        relevance_score: z.number(),
+        source_repo: z.string(),
+        tags: z.array(z.string()),
+      }),
+    ),
+    index_freshness: z.string(),
+  }),
+  execute: async ({ context }) => {
+    const documents = await fetchKnowledgeIndex();
+
+    const scored = documents
+      .map((doc) => ({
+        doc,
+        score: scoreDocument(doc, context.query, context.domain, context.tags),
+      }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, context.max_results ?? 5);
+
+    return {
+      query: context.query,
+      total_indexed: documents.length,
+      results: scored.map(({ doc, score }) => ({
+        id: doc.id,
+        title: doc.title,
+        domain: doc.domain,
+        path: doc.path,
+        word_count: doc.word_count,
+        summary: doc.summary,
+        relevance_score: score,
+        source_repo: doc.id.startsWith("qgia-library:")
+          ? "qgia-knowledge-library"
+          : "qgia-knowledge-spine",
+        tags: doc.tags,
+      })),
+      index_freshness: new Date().toISOString(),
+    };
+  },
+});

--- a/src/mastra/tools/qgiaForecastTool.ts
+++ b/src/mastra/tools/qgiaForecastTool.ts
@@ -1,0 +1,70 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const qgiaForecastTool = createTool({
+  id: "qgia-forecast",
+  description:
+    "Submit a geopolitical scenario to the QSFE (Quantum Superposition Forecasting Engine) for probabilistic forecast simulation. Constructs a forecast request conforming to the constellation forecast-request schema and returns the structured payload.",
+  inputSchema: z.object({
+    scenario: z.string().describe("Description of the geopolitical scenario to forecast"),
+    region: z
+      .string()
+      .describe("Primary geographic region (e.g., 'indo-pacific', 'middle-east', 'europe')"),
+    timeframe_months: z.number().min(1).max(120).describe("Forecast horizon in months"),
+    confidence_threshold: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.6)
+      .describe("Minimum confidence threshold for reported outcomes"),
+    include_cascades: z
+      .boolean()
+      .default(true)
+      .describe("Whether to include cascade/second-order effects"),
+    analyst_context: z
+      .string()
+      .optional()
+      .describe("Additional context or constraints for the forecast"),
+  }),
+  outputSchema: z.object({
+    request_id: z.string(),
+    forecast_request: z.object({
+      scenario: z.string(),
+      region: z.string(),
+      timeframe_months: z.number(),
+      confidence_threshold: z.number(),
+      include_cascades: z.boolean(),
+      analyst_context: z.string().optional(),
+    }),
+    constellation_endpoint: z.string(),
+    status: z.string(),
+    message: z.string(),
+  }),
+  execute: async ({ context }) => {
+    const requestId = `qsfe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const forecastRequest = {
+      scenario: context.scenario,
+      region: context.region,
+      timeframe_months: context.timeframe_months,
+      confidence_threshold: context.confidence_threshold ?? 0.6,
+      include_cascades: context.include_cascades ?? true,
+      analyst_context: context.analyst_context,
+    };
+
+    // In production, this would POST to the constellation gateway:
+    // const response = await fetch('https://api.aurora.constellation/v1/api/qgia/forecast', {
+    //   method: 'POST',
+    //   headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+    //   body: JSON.stringify(forecastRequest)
+    // });
+
+    return {
+      request_id: requestId,
+      forecast_request: forecastRequest,
+      constellation_endpoint: "/api/qgia/forecast",
+      status: "ready",
+      message: `Forecast request ${requestId} prepared for QSFE submission. Target region: ${context.region}, horizon: ${context.timeframe_months} months. Awaiting constellation gateway deployment for live execution.`,
+    };
+  },
+});


### PR DESCRIPTION
## Overview
Adds 3 new Mastra tools to AuroraOS that connect the agent runtime to the Aurora Constellation, and registers the node as **AURORA-RUNTIME** (`s.tag::aurora.runtime`).

## New Tools

### `qgiaForecastTool`
Constructs QSFE (Quantum Superposition Forecasting Engine) forecast requests. Accepts scenario descriptions, region, timeframe, and confidence thresholds. Currently builds structured request payloads ready for the constellation API gateway.

### `knowledgeQueryTool`  
Searches the QGIA knowledge base across the constellation. Fetches the aggregated knowledge index from PRIME (with fallback to individual spoke repos), performs relevance scoring against query terms, domain filters, and tag filters.

### `constellationStatusTool`
Health check for all 6 constellation nodes. Fetches `.aurora/constellation.json` manifests from each repo and reports status, connectivity, and node metadata.

## Changes
- **`src/mastra/tools/qgiaForecastTool.ts`** — New tool
- **`src/mastra/tools/knowledgeQueryTool.ts`** — New tool  
- **`src/mastra/tools/constellationStatusTool.ts`** — New tool
- **`src/mastra/index.ts`** — Imported and registered all 3 tools in MCP server
- **`.aurora/constellation.json`** — AURORA-RUNTIME node manifest

## Constraints Respected
- No new agents added (still exactly 1: auroraAgent)
- No new workflows added (still exactly 1: auroraSlackWorkflow)
- TypeScript type check passes